### PR TITLE
Remove unnecessary logging

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -11,6 +11,9 @@ logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s
                     level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Silence automatic logs of running scheduled tasks
+logging.getLogger('apscheduler.executors.default').setLevel(logging.WARNING)
+
 
 def log_error(update, context):
     """Log Errors caused by Updates."""


### PR DESCRIPTION
- Logs of running the scheduled jobs don't need to be collected since errors would be logged anyways.
- Two logs every minute makes logs congested and messy